### PR TITLE
Audio response: Time limit accepts '0' #378920

### DIFF
--- a/edit_recordrtc_form.php
+++ b/edit_recordrtc_form.php
@@ -51,7 +51,7 @@ class qtype_recordrtc_edit_form extends question_edit_form {
     public function validation($data, $files) {
         $errors = parent::validation($data, $files);
         $maxtimelimit = get_config('qtype_recordrtc', 'timelimit');
-        if ($data['timelimitinseconds'] === 0) {
+        if ($data['timelimitinseconds'] == 0) {
             $errors['timelimitinseconds'] = get_string('err_timliemitzero', 'qtype_recordrtc');
         } else if ($data['timelimitinseconds'] > $maxtimelimit) {
             $errors['timelimitinseconds'] = get_string('err_timliemit', 'qtype_recordrtc',

--- a/tests/behat/edit.feature
+++ b/tests/behat/edit.feature
@@ -28,11 +28,18 @@ Feature: Test editing record audio questions
   Scenario: Edit record audio question
     When I choose "Edit question" action for "Record audio question" in the question bank
     And I set the following fields to these values:
-      | Question name                | Edited question name |
-      | id_timelimitinseconds_number | 150                  |
+      | Question name                  | Edited question name |
+      | id_timelimitinseconds_number   | 11                   |
+      | id_timelimitinseconds_timeunit | minutes              |
     And I press "id_submitbutton"
-    Then I should see "The time limit cannot be greater than 2 mins."
+    Then I should see "The time limit cannot be greater than 10 mins."
     And I set the following fields to these values:
-      | id_timelimitinseconds_number | 15                   |
+      | id_timelimitinseconds_number   | 0       |
+      | id_timelimitinseconds_timeunit | seconds |
+    And I press "id_submitbutton"
+    Then I should see "The time limit cannot be zero."
+    And I set the following fields to these values:
+      | id_timelimitinseconds_number   | 15      |
+      | id_timelimitinseconds_timeunit | seconds |
     And I press "id_submitbutton"
     Then I should see "Edited question name"


### PR DESCRIPTION
This is now fixed. I used 'rtc-378920' (prefixed with 'rtc-', followed by tfs item number)