### PR TITLE
Fix error when records exist in questions but not in qtype_recordrtc_…

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -227,13 +227,15 @@ function xmldb_qtype_recordrtc_upgrade(int $oldversion): bool {
                 SELECT COUNT(1)
                   FROM {question} q
              LEFT JOIN {qtype_recordrtc_options} o ON o.questionid = q.id
-                 WHERE q.qtype = 'recordrtc'");
+                 WHERE q.qtype = 'recordrtc'
+                 AND o.id IS NOT NULL");
         if ($toupdatecount > 0) {
             $rs = $DB->get_recordset_sql("
                 SELECT o.id, q.defaultmark
                   FROM {question} q
              LEFT JOIN {qtype_recordrtc_options} o ON o.questionid = q.id
-                 WHERE q.qtype = 'recordrtc'");
+                 WHERE q.qtype = 'recordrtc'
+                 AND o.id IS NOT NULL");
             $pbar = new progress_bar('updaterecordrtcselfrate', 500, true);
 
             $done = 0;


### PR DESCRIPTION
…options

We ran into a problem when updating this plugin on a large instance. On closer inspection there were records in the mdl_question table that hat qtype 'recordrtc' set but which had no corresponding entry in mdl_qtype_recordrtc_options. 
I am not sure how common this situation is but this change should prevent this from breaking an update. 