### PR TITLE
Define class fields in question class to stop phpi 8.2 deprecation

### DIFF
--- a/question.php
+++ b/question.php
@@ -30,6 +30,16 @@ class qtype_recordrtc_question extends question_with_responses {
     public $widgets;
 
     /**
+     * @var int audio, video custom_av from the constants in question type.
+     */
+    public $mediatype;
+
+    /**
+     * @var int time limit before recording stops.
+     */
+    public $timelimitinseconds;
+
+    /**
      * @var bool whether the user can pause in the middle of recording.
      */
     public $allowpausing;


### PR DESCRIPTION
PHP 8.2 was throwing Deprecated: Creation of dynamic property qtype_recordrtc_question::$timelimitinseconds is deprecated 
and
Deprecated: Creation of dynamic property qtype_recordrtc_question::$mediatype is deprecated 
Messages when debug is set to developer.

I have created two new fields in the question class

Note: the ci errors do not seem to have been introduced by this code. There are at least 7 items that will be fixed with phpcbf.